### PR TITLE
ENHANCEMENT: Refactor docker compose structure and add extensions

### DIFF
--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -1,37 +1,39 @@
 version: '3.4'
 
+x-db-env: &db-env
+  POSTGRES_USER: admin
+  POSTGRES_PASSWORD: admin1234
+
 services:
+  customerdb:
+    container_name: customerdb
+    environment:
+      <<: *db-env
+      POSTGRES_DB: CustomerDb
+    restart: always
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    
+  accountdb:
+    container_name: accountdb
+    environment:
+     <<: *db-env
+     POSTGRES_DB: AccountDb
+    restart: always
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    
   transactiondb:
     container_name: transactiondb
     restart: always
     ports:
         - "27017:27017"
     volumes:
-        - mongo_data:/data/db
-
-  accountdb:
-    container_name: accountdb
-    environment:
-      - POSTGRES_USER=admin
-      - POSTGRES_PASSWORD=admin1234
-      - POSTGRES_DB=AccountDb
-    restart: always
-    ports:
-        - "5433:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data/  
-
-  customerdb:
-    container_name: customerdb
-    environment:
-      - POSTGRES_USER=admin
-      - POSTGRES_PASSWORD=admin1234
-      - POSTGRES_DB=CustomerDb
-    restart: always
-    ports:
-        - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data/      
+        - mongo_data:/data/db 
 
   rabbitmq:
     container_name: rabbitmq
@@ -61,18 +63,16 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - portainer_data:/data
 
-  transaction.api:
-    container_name: transaction.api
+  customer.api:
+    container_name: customer.api
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - "DatabaseSettings:ConnectionString=mongodb://transactiondb:27017"
-      - "EventBusSettings:HostAddress=amqp://guest:guest@rabbitmq:5672"
+      - "DatabaseSettings:ConnectionString=Server=customerdb;Port=5432;Database=CustomerDb;User Id=admin;Password=admin1234;"
       - "ElasticConfiguration:Uri=http://elasticsearch:9200"
     depends_on:
-      - transactiondb
-      - rabbitmq
+      - customerdb
     ports:
-      - "8002:80"
+      - "8000:80"
 
   account.api:
     container_name: account.api
@@ -88,16 +88,18 @@ services:
     ports:
       - "8001:80"
 
-  customer.api:
-    container_name: customer.api
+  transaction.api:
+    container_name: transaction.api
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - "DatabaseSettings:ConnectionString=Server=customerdb;Port=5432;Database=CustomerDb;User Id=admin;Password=admin1234;"
+      - "DatabaseSettings:ConnectionString=mongodb://transactiondb:27017"
+      - "EventBusSettings:HostAddress=amqp://guest:guest@rabbitmq:5672"
       - "ElasticConfiguration:Uri=http://elasticsearch:9200"
     depends_on:
-      - customerdb
+      - transactiondb
+      - rabbitmq
     ports:
-      - "8000:80"
+      - "8002:80"
 
   customer.grpc:
     container_name: customer.grpc

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -19,11 +19,11 @@ services:
   portainer:
     image: portainer/portainer-ce
 
-  transaction.api:
-    image: ${DOCKER_REGISTRY-}transactionapi
+  customer.api:
+    image: ${DOCKER_REGISTRY-}customerapi
     build:
       context: .
-      dockerfile: Services/Transaction/Transaction.API/Dockerfile
+      dockerfile: Services/Customer/Customer.API/Dockerfile
 
   account.api:
     image: ${DOCKER_REGISTRY-}accountapi
@@ -31,20 +31,17 @@ services:
       context: .
       dockerfile: Services/Account/Account.API/Dockerfile
 
-
-  customer.api:
-    image: ${DOCKER_REGISTRY-}customerapi
+  transaction.api:
+    image: ${DOCKER_REGISTRY-}transactionapi
     build:
       context: .
-      dockerfile: Services/Customer/Customer.API/Dockerfile
-
+      dockerfile: Services/Transaction/Transaction.API/Dockerfile
 
   customer.grpc:
     image: ${DOCKER_REGISTRY-}customergrpc
     build:
       context: .
       dockerfile: Services/Customer/Customer.GRPC/Dockerfile
-
 
   ocelotapigateway:
     image: ${DOCKER_REGISTRY-}ocelotapigateway


### PR DESCRIPTION
<h3>Changes made 🛠️</h3>
<hr/>
<h2>Files changed:</h2>
1. docker-compose.yml
<br/>
2. docker-compose.override.yml
<hr/>
<h2>Modifications:</h2>

1. Reorganize services order
2. Add docker compose extension fields

<hr/>

Additional note to consider: Many users have installed `PostgreSQL` on port `5432`, which you have defined in the `docker-compose.override.yml` file. This can lead to installation errors. While I didn’t change the port in this pull request, I recommend modifying it to prevent potential confusion for others.

`Error response from daemon: driver failed programming external connectivity on endpoint customerdb (836315321d6f869d08afb46126ed04263569bed6ee24b7028a1301666fdf75e7): Error starting userland proxy: listen tcp4 0.0.0.0:5432: bind: address already in use`

All you need to modify is the following:

```
services:
  customerdb:
    container_name: customerdb
    environment:
      <<: *db-env
      POSTGRES_DB: CustomerDb
    restart: always
    ports:
      - "5432:5432"
    volumes:
      - postgres_data:/var/lib/postgresql/data/
```